### PR TITLE
feat: add MiniMax as third LLM provider in Chapter 10

### DIFF
--- a/03-ai-agent-for-devops/10-building-complex-agent-with-actions.md
+++ b/03-ai-agent-for-devops/10-building-complex-agent-with-actions.md
@@ -332,9 +332,13 @@ def create_model():
         from .github_openai import GitHubModel
         return GitHubModel()
 
+    if provider == "minimax":
+        from .minimax import MiniMaxModel
+        return MiniMaxModel()
+
     raise ValueError(
         f"Unknown LLM_PROVIDER '{provider}'. "
-        "Supported values: gemini, github"
+        "Supported values: gemini, github, minimax"
     )
 ```
 
@@ -382,6 +386,27 @@ GITHUB_MODEL=openai/gpt-4.1
 ```
 
 The GitHub Models endpoint is OpenAI-compatible, so we use `ChatOpenAI` from `langchain-openai` with a custom `base_url`. This is a pattern you'll see frequently—many AI providers expose OpenAI-compatible APIs.
+
+Adding a third provider like [MiniMax](https://www.minimax.io) follows the same pattern:
+
+```python
+# src/models/minimax.py
+
+class MiniMaxModel:
+    def __init__(self):
+        temperature = max(Config.TEMPERATURE, 0.01)  # MiniMax requires > 0
+        self.llm = ChatOpenAI(
+            model=Config.MINIMAX_MODEL,
+            api_key=Config.MINIMAX_API_KEY,
+            base_url=Config.MINIMAX_ENDPOINT,
+            temperature=temperature,
+        )
+
+    def get_llm_with_tools(self, tools: list):
+        return self.llm.bind_tools(tools)
+```
+
+MiniMax's API is also OpenAI-compatible, so we reuse `ChatOpenAI` with a different `base_url`. The only twist is temperature clamping—MiniMax requires a strictly positive value, so we clamp `0.0` to `0.01`.
 
 ## The Agent
 
@@ -695,18 +720,23 @@ The `Config` class manages all environment variables in one place:
 # src/config.py
 
 class Config:
-    # LLM Provider selection: 'gemini' (default) or 'github'
+    # LLM Provider selection: 'gemini' (default), 'github', or 'minimax'
     LLM_PROVIDER = os.getenv('LLM_PROVIDER', 'gemini').lower()
-    
+
     # Gemini
     GEMINI_API_KEY = os.getenv('GEMINI_API_KEY')
     GEMINI_MODEL = os.getenv('GEMINI_MODEL', 'gemini-2.5-flash')
-    
+
     # GitHub Models
     GITHUB_TOKEN = os.getenv('GITHUB_TOKEN', '')
     GITHUB_MODEL = os.getenv('GITHUB_MODEL', 'openai/gpt-5')
     GITHUB_ENDPOINT = os.getenv('GITHUB_ENDPOINT', 'https://models.github.ai/inference')
-    
+
+    # MiniMax
+    MINIMAX_API_KEY = os.getenv('MINIMAX_API_KEY', '')
+    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M2.7')
+    MINIMAX_ENDPOINT = os.getenv('MINIMAX_ENDPOINT', 'https://api.minimax.io/v1')
+
     # AWS
     AWS_REGION = os.getenv('AWS_REGION', 'us-east-1')
     AWS_RDS_INSTANCE_ID = os.getenv('AWS_RDS_INSTANCE_ID', '')
@@ -732,6 +762,10 @@ def validate(cls):
     if cls.LLM_PROVIDER == 'github' and not cls.GITHUB_TOKEN:
         raise ValueError(
             "LLM_PROVIDER=github but GITHUB_TOKEN is not set."
+        )
+    if cls.LLM_PROVIDER == 'minimax' and not cls.MINIMAX_API_KEY:
+        raise ValueError(
+            "LLM_PROVIDER=minimax but MINIMAX_API_KEY is not set."
         )
 ```
 
@@ -958,6 +992,11 @@ GEMINI_API_KEY=your_api_key_here
 # LLM_PROVIDER=github
 # GITHUB_TOKEN=your_github_token_here
 # GITHUB_MODEL=openai/gpt-4.1
+
+# Option C: MiniMax
+# LLM_PROVIDER=minimax
+# MINIMAX_API_KEY=your_minimax_api_key_here
+# MINIMAX_MODEL=MiniMax-M2.7
 ```
 
 4. Start the application:

--- a/03-ai-agent-for-devops/code/10/.env.example
+++ b/03-ai-agent-for-devops/code/10/.env.example
@@ -1,11 +1,24 @@
 # Environment variables for the AI Logging Agent - Chapter 10
 
-# Required: Your Google Gemini API key
+# LLM Provider: 'gemini' (default), 'github', or 'minimax'
+# LLM_PROVIDER=gemini
+
+# Required (when using Gemini): Your Google Gemini API key
 GEMINI_API_KEY=your_api_key_here
 
 # Optional: Model configuration
 GEMINI_MODEL=gemini-2.5-flash
 TEMPERATURE=0.1
+
+# Optional: GitHub Models Configuration
+# LLM_PROVIDER=github
+# GITHUB_TOKEN=your_github_token_here
+# GITHUB_MODEL=openai/gpt-5
+
+# Optional: MiniMax Configuration
+# LLM_PROVIDER=minimax
+# MINIMAX_API_KEY=your_minimax_api_key_here
+# MINIMAX_MODEL=MiniMax-M2.7
 
 # Optional: Log directory path
 LOG_DIRECTORY=logs

--- a/03-ai-agent-for-devops/code/10/README.md
+++ b/03-ai-agent-for-devops/code/10/README.md
@@ -47,9 +47,12 @@ Three-Tier Application on AWS:
 ├── system_prompt.txt         # AI agent instructions (AWS-focused)
 ├── src/
 │   ├── __init__.py
-│   ├── config.py            # Configuration (Gemini + AWS + Slack)
+│   ├── config.py            # Configuration (Gemini + GitHub + MiniMax + AWS + Slack)
 │   ├── models/
-│   │   └── gemini.py
+│   │   ├── gemini.py        # Google Gemini provider
+│   │   ├── github_openai.py # GitHub Models provider
+│   │   ├── minimax.py       # MiniMax provider
+│   │   └── factory.py       # Provider selection factory
 │   ├── tools/
 │   │   ├── log_reader.py    # Log reading tools
 │   │   ├── actions.py       # Kubernetes pod restart
@@ -84,8 +87,18 @@ pip install -r requirements.txt
 3. **Set up environment:**
 ```bash
 cp .env.example .env
-# Edit .env and add your GEMINI_API_KEY
+# Edit .env and add your API key for the chosen provider
 ```
+
+**Supported LLM providers:**
+
+| Provider | Env Var | Default Model |
+|----------|---------|---------------|
+| Google Gemini | `GEMINI_API_KEY` | `gemini-2.5-flash` |
+| GitHub Models | `GITHUB_TOKEN` | `openai/gpt-5` |
+| [MiniMax](https://www.minimax.io) | `MINIMAX_API_KEY` | `MiniMax-M2.7` |
+
+Set `LLM_PROVIDER` to `gemini`, `github`, or `minimax` in your `.env` file.
 
 ## Usage
 

--- a/03-ai-agent-for-devops/code/10/app.py
+++ b/03-ai-agent-for-devops/code/10/app.py
@@ -151,7 +151,7 @@ def sidebar():
         st.markdown("---")
 
         st.subheader("Configuration")
-        provider = {"gemini": "Gemini", "github": "GitHub Models"}.get(
+        provider = {"gemini": "Gemini", "github": "GitHub Models", "minimax": "MiniMax"}.get(
             Config.LLM_PROVIDER, Config.LLM_PROVIDER,
         )
         st.markdown(f"- Provider: **{provider}**")

--- a/03-ai-agent-for-devops/code/10/src/config.py
+++ b/03-ai-agent-for-devops/code/10/src/config.py
@@ -16,13 +16,18 @@ class Config:
     GEMINI_MODEL = os.getenv('GEMINI_MODEL', 'gemini-2.5-flash')
     TEMPERATURE = float(os.getenv('TEMPERATURE', '0.1'))
     
-    # LLM Provider selection: 'gemini' (default) or 'github'
+    # LLM Provider selection: 'gemini' (default), 'github', or 'minimax'
     LLM_PROVIDER = os.getenv('LLM_PROVIDER', 'gemini').lower()
-    
+
     # GitHub Models Configuration
     GITHUB_TOKEN = os.getenv('GITHUB_TOKEN', '')
     GITHUB_MODEL = os.getenv('GITHUB_MODEL', 'openai/gpt-5')
     GITHUB_ENDPOINT = os.getenv('GITHUB_ENDPOINT', 'https://models.github.ai/inference')
+
+    # MiniMax Configuration
+    MINIMAX_API_KEY = os.getenv('MINIMAX_API_KEY', '')
+    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M2.7')
+    MINIMAX_ENDPOINT = os.getenv('MINIMAX_ENDPOINT', 'https://api.minimax.io/v1')
     
     # Paths
     LOG_DIRECTORY = os.getenv('LOG_DIRECTORY', 'logs')
@@ -74,6 +79,11 @@ class Config:
         if cls.LLM_PROVIDER == 'github' and not cls.GITHUB_TOKEN:
             raise ValueError(
                 "LLM_PROVIDER=github but GITHUB_TOKEN is not set. "
+                "Please set it in .env file or environment variables."
+            )
+        if cls.LLM_PROVIDER == 'minimax' and not cls.MINIMAX_API_KEY:
+            raise ValueError(
+                "LLM_PROVIDER=minimax but MINIMAX_API_KEY is not set. "
                 "Please set it in .env file or environment variables."
             )
         

--- a/03-ai-agent-for-devops/code/10/src/models/__init__.py
+++ b/03-ai-agent-for-devops/code/10/src/models/__init__.py
@@ -3,6 +3,7 @@ LLM models package
 """
 from .gemini import GeminiModel
 from .github_openai import GitHubModel
+from .minimax import MiniMaxModel
 from .factory import create_model
 
-__all__ = ['GeminiModel', 'GitHubModel', 'create_model']
+__all__ = ['GeminiModel', 'GitHubModel', 'MiniMaxModel', 'create_model']

--- a/03-ai-agent-for-devops/code/10/src/models/factory.py
+++ b/03-ai-agent-for-devops/code/10/src/models/factory.py
@@ -4,6 +4,7 @@ Model factory — selects the LLM provider from the LLM_PROVIDER env variable.
 Supported values:
   gemini   — Google Gemini (default)
   github   — GitHub Models (OpenAI-compatible endpoint)
+  minimax  — MiniMax (OpenAI-compatible endpoint)
 """
 from ..config import Config
 
@@ -25,7 +26,11 @@ def create_model():
         from .github_openai import GitHubModel
         return GitHubModel()
 
+    if provider == "minimax":
+        from .minimax import MiniMaxModel
+        return MiniMaxModel()
+
     raise ValueError(
         f"Unknown LLM_PROVIDER '{provider}'. "
-        "Supported values: gemini, github"
+        "Supported values: gemini, github, minimax"
     )

--- a/03-ai-agent-for-devops/code/10/src/models/minimax.py
+++ b/03-ai-agent-for-devops/code/10/src/models/minimax.py
@@ -1,0 +1,27 @@
+"""
+MiniMax LLM wrapper (OpenAI-compatible endpoint)
+"""
+from langchain_openai import ChatOpenAI
+from ..config import Config
+
+
+class MiniMaxModel:
+    """Wrapper for MiniMax via OpenAI-compatible inference endpoint."""
+
+    def __init__(self):
+        # MiniMax requires temperature in (0.0, 1.0]
+        temperature = max(Config.TEMPERATURE, 0.01)
+        self.llm = ChatOpenAI(
+            model=Config.MINIMAX_MODEL,
+            api_key=Config.MINIMAX_API_KEY,
+            base_url=Config.MINIMAX_ENDPOINT,
+            temperature=temperature,
+        )
+
+    def get_llm(self):
+        """Get the LLM instance"""
+        return self.llm
+
+    def get_llm_with_tools(self, tools: list):
+        """Get LLM with tools bound"""
+        return self.llm.bind_tools(tools)

--- a/03-ai-agent-for-devops/code/10/tests/test_minimax.py
+++ b/03-ai-agent-for-devops/code/10/tests/test_minimax.py
@@ -1,0 +1,351 @@
+"""
+Unit tests for MiniMax LLM provider integration.
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+from importlib import reload
+
+# Add parent directory to path so we can import the src module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+def _reload_all():
+    """Reload config and model modules to pick up env var changes."""
+    import src.config
+    reload(src.config)
+    import src.models.minimax
+    reload(src.models.minimax)
+    import src.models.factory
+    reload(src.models.factory)
+    import src.models
+    reload(src.models)
+
+
+class TestMiniMaxModel(unittest.TestCase):
+    """Tests for MiniMaxModel class."""
+
+    @patch.dict(os.environ, {
+        'MINIMAX_API_KEY': 'test-key-123',
+        'MINIMAX_MODEL': 'MiniMax-M2.7',
+        'MINIMAX_ENDPOINT': 'https://api.minimax.io/v1',
+        'TEMPERATURE': '0.5',
+        'LLM_PROVIDER': 'minimax',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_minimax_model_init(self, mock_chat):
+        """MiniMaxModel initializes ChatOpenAI with correct params."""
+        _reload_all()
+        from src.models.minimax import MiniMaxModel
+
+        model = MiniMaxModel()
+        mock_chat.assert_called_once_with(
+            model='MiniMax-M2.7',
+            api_key='test-key-123',
+            base_url='https://api.minimax.io/v1',
+            temperature=0.5,
+        )
+
+    @patch.dict(os.environ, {
+        'MINIMAX_API_KEY': 'test-key-123',
+        'TEMPERATURE': '0.0',
+        'LLM_PROVIDER': 'minimax',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_minimax_temperature_clamping(self, mock_chat):
+        """MiniMax clamps temperature=0.0 to 0.01."""
+        _reload_all()
+        from src.models.minimax import MiniMaxModel
+
+        model = MiniMaxModel()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertAlmostEqual(call_kwargs['temperature'], 0.01)
+
+    @patch.dict(os.environ, {
+        'MINIMAX_API_KEY': 'test-key-123',
+        'TEMPERATURE': '0.7',
+        'LLM_PROVIDER': 'minimax',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_minimax_temperature_passthrough(self, mock_chat):
+        """Non-zero temperature passes through unchanged."""
+        _reload_all()
+        from src.models.minimax import MiniMaxModel
+
+        model = MiniMaxModel()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertAlmostEqual(call_kwargs['temperature'], 0.7)
+
+    @patch.dict(os.environ, {
+        'MINIMAX_API_KEY': 'test-key-123',
+        'TEMPERATURE': '0.3',
+        'LLM_PROVIDER': 'minimax',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_minimax_get_llm(self, mock_chat):
+        """get_llm() returns the underlying LLM instance."""
+        _reload_all()
+        from src.models.minimax import MiniMaxModel
+
+        model = MiniMaxModel()
+        llm = model.get_llm()
+        self.assertIs(llm, mock_chat.return_value)
+
+    @patch.dict(os.environ, {
+        'MINIMAX_API_KEY': 'test-key-123',
+        'TEMPERATURE': '0.3',
+        'LLM_PROVIDER': 'minimax',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_minimax_get_llm_with_tools(self, mock_chat):
+        """get_llm_with_tools() binds tools to the LLM."""
+        _reload_all()
+        from src.models.minimax import MiniMaxModel
+
+        mock_llm = mock_chat.return_value
+        mock_bound = MagicMock()
+        mock_llm.bind_tools.return_value = mock_bound
+
+        model = MiniMaxModel()
+        tools = [MagicMock(), MagicMock()]
+        result = model.get_llm_with_tools(tools)
+
+        mock_llm.bind_tools.assert_called_once_with(tools)
+        self.assertIs(result, mock_bound)
+
+    @patch.dict(os.environ, {
+        'MINIMAX_API_KEY': 'test-key-123',
+        'LLM_PROVIDER': 'minimax',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_minimax_default_model(self, mock_chat):
+        """Default model is MiniMax-M2.7."""
+        _reload_all()
+        from src.models.minimax import MiniMaxModel
+
+        model = MiniMaxModel()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs['model'], 'MiniMax-M2.7')
+
+    @patch.dict(os.environ, {
+        'MINIMAX_API_KEY': 'test-key-123',
+        'MINIMAX_MODEL': 'MiniMax-M2.7-highspeed',
+        'LLM_PROVIDER': 'minimax',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_minimax_custom_model(self, mock_chat):
+        """Custom model name from env is used."""
+        _reload_all()
+        from src.models.minimax import MiniMaxModel
+
+        model = MiniMaxModel()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs['model'], 'MiniMax-M2.7-highspeed')
+
+    @patch.dict(os.environ, {
+        'MINIMAX_API_KEY': 'test-key-123',
+        'LLM_PROVIDER': 'minimax',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_minimax_default_endpoint(self, mock_chat):
+        """Default endpoint is https://api.minimax.io/v1."""
+        _reload_all()
+        from src.models.minimax import MiniMaxModel
+
+        model = MiniMaxModel()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs['base_url'], 'https://api.minimax.io/v1')
+
+    @patch.dict(os.environ, {
+        'MINIMAX_API_KEY': 'test-key-123',
+        'MINIMAX_ENDPOINT': 'https://custom.endpoint.com/v1',
+        'LLM_PROVIDER': 'minimax',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_minimax_custom_endpoint(self, mock_chat):
+        """Custom endpoint from env is used."""
+        _reload_all()
+        from src.models.minimax import MiniMaxModel
+
+        model = MiniMaxModel()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs['base_url'], 'https://custom.endpoint.com/v1')
+
+    @patch.dict(os.environ, {
+        'MINIMAX_API_KEY': 'test-key-123',
+        'TEMPERATURE': '1.0',
+        'LLM_PROVIDER': 'minimax',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_minimax_max_temperature(self, mock_chat):
+        """Temperature=1.0 passes through (max allowed)."""
+        _reload_all()
+        from src.models.minimax import MiniMaxModel
+
+        model = MiniMaxModel()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertAlmostEqual(call_kwargs['temperature'], 1.0)
+
+
+class TestModelFactory(unittest.TestCase):
+    """Tests for the model factory with MiniMax provider."""
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'minimax',
+        'MINIMAX_API_KEY': 'test-key-123',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_factory_creates_minimax(self, mock_chat):
+        """create_model() returns MiniMaxModel when LLM_PROVIDER=minimax."""
+        _reload_all()
+        from src.models.factory import create_model
+        from src.models.minimax import MiniMaxModel
+
+        model = create_model()
+        self.assertIsInstance(model, MiniMaxModel)
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'unknown_provider',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    def test_factory_rejects_unknown(self):
+        """create_model() raises ValueError for unknown providers."""
+        _reload_all()
+        from src.models.factory import create_model
+
+        with self.assertRaises(ValueError) as ctx:
+            create_model()
+        self.assertIn('minimax', str(ctx.exception).lower())
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'minimax',
+        'MINIMAX_API_KEY': 'test-key-123',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_factory_minimax_has_get_llm(self, mock_chat):
+        """Factory-created MiniMax model has get_llm method."""
+        _reload_all()
+        from src.models.factory import create_model
+
+        model = create_model()
+        self.assertTrue(hasattr(model, 'get_llm'))
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'minimax',
+        'MINIMAX_API_KEY': 'test-key-123',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    @patch('langchain_openai.ChatOpenAI')
+    def test_factory_minimax_has_get_llm_with_tools(self, mock_chat):
+        """Factory-created MiniMax model has get_llm_with_tools method."""
+        _reload_all()
+        from src.models.factory import create_model
+
+        model = create_model()
+        self.assertTrue(hasattr(model, 'get_llm_with_tools'))
+
+
+class TestConfigValidation(unittest.TestCase):
+    """Tests for Config validation with MiniMax provider."""
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'minimax',
+        'MINIMAX_API_KEY': '',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    def test_validate_minimax_missing_key(self):
+        """Config.validate() raises when MINIMAX_API_KEY is empty."""
+        import src.config
+        with self.assertRaises(ValueError) as ctx:
+            reload(src.config)
+        self.assertIn('MINIMAX_API_KEY', str(ctx.exception))
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'minimax',
+        'MINIMAX_API_KEY': 'test-key-123',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    def test_validate_minimax_with_key(self):
+        """Config.validate() passes when MINIMAX_API_KEY is set."""
+        _reload_all()
+        from src.config import Config
+        self.assertEqual(Config.LLM_PROVIDER, 'minimax')
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'minimax',
+        'MINIMAX_API_KEY': 'test-key-123',
+        'MINIMAX_MODEL': 'MiniMax-M2.7',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    def test_config_minimax_defaults(self):
+        """Config has correct MiniMax default values."""
+        _reload_all()
+        from src.config import Config
+
+        self.assertEqual(Config.MINIMAX_ENDPOINT, 'https://api.minimax.io/v1')
+        self.assertEqual(Config.MINIMAX_MODEL, 'MiniMax-M2.7')
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'minimax',
+        'MINIMAX_API_KEY': 'test-key-123',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    def test_config_minimax_provider_value(self):
+        """Config.LLM_PROVIDER is 'minimax' when set."""
+        _reload_all()
+        from src.config import Config
+        self.assertEqual(Config.LLM_PROVIDER, 'minimax')
+
+
+class TestModelExports(unittest.TestCase):
+    """Tests for models package __init__ exports."""
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'minimax',
+        'MINIMAX_API_KEY': 'test-key-123',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    def test_minimax_model_importable(self):
+        """MiniMaxModel is importable from src.models."""
+        _reload_all()
+        from src.models import MiniMaxModel
+        self.assertIsNotNone(MiniMaxModel)
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'minimax',
+        'MINIMAX_API_KEY': 'test-key-123',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    def test_create_model_importable(self):
+        """create_model is importable from src.models."""
+        _reload_all()
+        from src.models import create_model
+        self.assertIsNotNone(create_model)
+
+    @patch.dict(os.environ, {
+        'LLM_PROVIDER': 'minimax',
+        'MINIMAX_API_KEY': 'test-key-123',
+        'LOG_DIRECTORY': '/tmp/test-logs',
+    })
+    def test_minimax_in_all(self):
+        """MiniMaxModel is listed in __all__."""
+        _reload_all()
+        from src import models
+        self.assertIn('MiniMaxModel', models.__all__)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/03-ai-agent-for-devops/code/10/tests/test_minimax_integration.py
+++ b/03-ai-agent-for-devops/code/10/tests/test_minimax_integration.py
@@ -1,0 +1,70 @@
+"""
+Integration tests for MiniMax LLM provider.
+
+These tests verify end-to-end behavior against the real MiniMax API.
+They are skipped if MINIMAX_API_KEY is not set in the environment.
+
+Run with:
+    MINIMAX_API_KEY=your_key python -m pytest tests/test_minimax_integration.py -v
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+SKIP_REASON = "MINIMAX_API_KEY not set — skipping integration tests"
+
+
+@unittest.skipUnless(os.getenv('MINIMAX_API_KEY'), SKIP_REASON)
+class TestMiniMaxIntegration(unittest.TestCase):
+    """Integration tests against live MiniMax API."""
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ.setdefault('LLM_PROVIDER', 'minimax')
+        os.environ.setdefault('MINIMAX_MODEL', 'MiniMax-M2.7')
+        os.environ.setdefault('LOG_DIRECTORY', '/tmp/test-logs')
+        os.makedirs('/tmp/test-logs', exist_ok=True)
+
+        from importlib import reload
+        import src.config
+        reload(src.config)
+
+    def test_minimax_chat_completion(self):
+        """MiniMax can produce a basic chat completion."""
+        from src.models.minimax import MiniMaxModel
+        model = MiniMaxModel()
+        llm = model.get_llm()
+        response = llm.invoke("Say hello in one word.")
+        self.assertTrue(len(response.content) > 0)
+
+    def test_minimax_tool_binding(self):
+        """MiniMax model accepts tool bindings."""
+        from langchain_core.tools import tool
+
+        @tool
+        def get_time() -> str:
+            """Get the current time."""
+            return "12:00 PM"
+
+        from src.models.minimax import MiniMaxModel
+        model = MiniMaxModel()
+        llm_with_tools = model.get_llm_with_tools([get_time])
+        response = llm_with_tools.invoke("What time is it?")
+        # Response should have content or tool_calls
+        self.assertTrue(
+            response.content or getattr(response, 'tool_calls', None)
+        )
+
+    def test_factory_minimax_integration(self):
+        """Factory creates a working MiniMax model."""
+        from src.models.factory import create_model
+        model = create_model()
+        llm = model.get_llm()
+        response = llm.invoke("Reply with just the word 'ok'.")
+        self.assertTrue(len(response.content) > 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimax.io) as a third LLM provider alongside Google Gemini and GitHub Models in the AI Agent for DevOps tutorial (Chapter 10).

MiniMax exposes an OpenAI-compatible API, so it reuses `ChatOpenAI` from `langchain-openai` with a custom `base_url` — the same pattern already established for GitHub Models. This gives readers another provider option they can switch to with a single `LLM_PROVIDER=minimax` environment variable.

### Changes (10 files, 543 additions)

- **New** `src/models/minimax.py` — MiniMaxModel wrapper with temperature clamping (MiniMax requires > 0)
- **Updated** `src/models/factory.py` — added `minimax` to provider dispatch
- **Updated** `src/models/__init__.py` — exports MiniMaxModel
- **Updated** `src/config.py` — added `MINIMAX_API_KEY`, `MINIMAX_MODEL`, `MINIMAX_ENDPOINT` config vars with validation
- **Updated** `.env.example` — documented MiniMax env vars
- **Updated** `app.py` — sidebar now shows MiniMax provider label
- **Updated** `README.md` — added MiniMax to provider table and project structure
- **Updated** `10-building-complex-agent-with-actions.md` — added MiniMax code example, config, and validation in tutorial text
- **New** `tests/test_minimax.py` — 21 unit tests (model init, temperature clamping, factory, config validation, exports)
- **New** `tests/test_minimax_integration.py` — 3 integration tests (chat completion, tool binding, factory)

### Models supported

| Model | Context | Notes |
|-------|---------|-------|
| `MiniMax-M2.7` (default) | 1M tokens | Latest flagship model |
| `MiniMax-M2.7-highspeed` | 1M tokens | Faster variant |

## Test plan

- [x] All 21 unit tests pass (`python -m pytest tests/test_minimax.py`)
- [x] All 3 integration tests pass with live API key
- [ ] Verify `LLM_PROVIDER=minimax` works with `streamlit run app.py`
- [ ] Verify existing Gemini/GitHub providers still work unchanged
