### PR TITLE
Upgrade MiniMax default model to M3

### DIFF
--- a/03-ai-agent-for-devops/10-building-complex-agent-with-actions.md
+++ b/03-ai-agent-for-devops/10-building-complex-agent-with-actions.md
@@ -734,7 +734,7 @@ class Config:
 
     # MiniMax
     MINIMAX_API_KEY = os.getenv('MINIMAX_API_KEY', '')
-    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M2.7')
+    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M3')
     MINIMAX_ENDPOINT = os.getenv('MINIMAX_ENDPOINT', 'https://api.minimax.io/v1')
 
     # AWS
@@ -996,7 +996,7 @@ GEMINI_API_KEY=your_api_key_here
 # Option C: MiniMax
 # LLM_PROVIDER=minimax
 # MINIMAX_API_KEY=your_minimax_api_key_here
-# MINIMAX_MODEL=MiniMax-M2.7
+# MINIMAX_MODEL=MiniMax-M3
 ```
 
 4. Start the application:

--- a/03-ai-agent-for-devops/code/10/.env.example
+++ b/03-ai-agent-for-devops/code/10/.env.example
@@ -18,7 +18,7 @@ TEMPERATURE=0.1
 # Optional: MiniMax Configuration
 # LLM_PROVIDER=minimax
 # MINIMAX_API_KEY=your_minimax_api_key_here
-# MINIMAX_MODEL=MiniMax-M2.7
+# MINIMAX_MODEL=MiniMax-M3
 
 # Optional: Log directory path
 LOG_DIRECTORY=logs

--- a/03-ai-agent-for-devops/code/10/README.md
+++ b/03-ai-agent-for-devops/code/10/README.md
@@ -96,7 +96,7 @@ cp .env.example .env
 |----------|---------|---------------|
 | Google Gemini | `GEMINI_API_KEY` | `gemini-2.5-flash` |
 | GitHub Models | `GITHUB_TOKEN` | `openai/gpt-5` |
-| [MiniMax](https://www.minimax.io) | `MINIMAX_API_KEY` | `MiniMax-M2.7` |
+| [MiniMax](https://www.minimax.io) | `MINIMAX_API_KEY` | `MiniMax-M3` |
 
 Set `LLM_PROVIDER` to `gemini`, `github`, or `minimax` in your `.env` file.
 

--- a/03-ai-agent-for-devops/code/10/src/config.py
+++ b/03-ai-agent-for-devops/code/10/src/config.py
@@ -26,7 +26,7 @@ class Config:
 
     # MiniMax Configuration
     MINIMAX_API_KEY = os.getenv('MINIMAX_API_KEY', '')
-    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M2.7')
+    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M3')
     MINIMAX_ENDPOINT = os.getenv('MINIMAX_ENDPOINT', 'https://api.minimax.io/v1')
     
     # Paths

--- a/03-ai-agent-for-devops/code/10/tests/test_minimax.py
+++ b/03-ai-agent-for-devops/code/10/tests/test_minimax.py
@@ -126,13 +126,13 @@ class TestMiniMaxModel(unittest.TestCase):
     })
     @patch('langchain_openai.ChatOpenAI')
     def test_minimax_default_model(self, mock_chat):
-        """Default model is MiniMax-M2.7."""
+        """Default model is MiniMax-M3."""
         _reload_all()
         from src.models.minimax import MiniMaxModel
 
         model = MiniMaxModel()
         call_kwargs = mock_chat.call_args[1]
-        self.assertEqual(call_kwargs['model'], 'MiniMax-M2.7')
+        self.assertEqual(call_kwargs['model'], 'MiniMax-M3')
 
     @patch.dict(os.environ, {
         'MINIMAX_API_KEY': 'test-key-123',
@@ -287,7 +287,7 @@ class TestConfigValidation(unittest.TestCase):
     @patch.dict(os.environ, {
         'LLM_PROVIDER': 'minimax',
         'MINIMAX_API_KEY': 'test-key-123',
-        'MINIMAX_MODEL': 'MiniMax-M2.7',
+        'MINIMAX_MODEL': 'MiniMax-M3',
         'LOG_DIRECTORY': '/tmp/test-logs',
     })
     def test_config_minimax_defaults(self):
@@ -296,7 +296,7 @@ class TestConfigValidation(unittest.TestCase):
         from src.config import Config
 
         self.assertEqual(Config.MINIMAX_ENDPOINT, 'https://api.minimax.io/v1')
-        self.assertEqual(Config.MINIMAX_MODEL, 'MiniMax-M2.7')
+        self.assertEqual(Config.MINIMAX_MODEL, 'MiniMax-M3')
 
     @patch.dict(os.environ, {
         'LLM_PROVIDER': 'minimax',

--- a/03-ai-agent-for-devops/code/10/tests/test_minimax_integration.py
+++ b/03-ai-agent-for-devops/code/10/tests/test_minimax_integration.py
@@ -23,7 +23,7 @@ class TestMiniMaxIntegration(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         os.environ.setdefault('LLM_PROVIDER', 'minimax')
-        os.environ.setdefault('MINIMAX_MODEL', 'MiniMax-M2.7')
+        os.environ.setdefault('MINIMAX_MODEL', 'MiniMax-M3')
         os.environ.setdefault('LOG_DIRECTORY', '/tmp/test-logs')
         os.makedirs('/tmp/test-logs', exist_ok=True)
 

--- a/03-ai-agent-for-devops/code/12/.env.example
+++ b/03-ai-agent-for-devops/code/12/.env.example
@@ -18,7 +18,7 @@ TEMPERATURE=0.1
 # Optional: MiniMax Configuration
 # LLM_PROVIDER=minimax
 # MINIMAX_API_KEY=your_minimax_api_key_here
-# MINIMAX_MODEL=MiniMax-M2.7
+# MINIMAX_MODEL=MiniMax-M3
 
 # Optional: Log directory path
 LOG_DIRECTORY=logs

--- a/03-ai-agent-for-devops/code/12/src/config.py
+++ b/03-ai-agent-for-devops/code/12/src/config.py
@@ -26,7 +26,7 @@ class Config:
 
     # MiniMax Configuration
     MINIMAX_API_KEY = os.getenv('MINIMAX_API_KEY', '')
-    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M2.7')
+    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M3')
     MINIMAX_ENDPOINT = os.getenv('MINIMAX_ENDPOINT', 'https://api.minimax.io/v1')
     
     # Paths

--- a/03-ai-agent-for-devops/code/12/tests/test_minimax.py
+++ b/03-ai-agent-for-devops/code/12/tests/test_minimax.py
@@ -126,13 +126,13 @@ class TestMiniMaxModel(unittest.TestCase):
     })
     @patch('langchain_openai.ChatOpenAI')
     def test_minimax_default_model(self, mock_chat):
-        """Default model is MiniMax-M2.7."""
+        """Default model is MiniMax-M3."""
         _reload_all()
         from src.models.minimax import MiniMaxModel
 
         model = MiniMaxModel()
         call_kwargs = mock_chat.call_args[1]
-        self.assertEqual(call_kwargs['model'], 'MiniMax-M2.7')
+        self.assertEqual(call_kwargs['model'], 'MiniMax-M3')
 
     @patch.dict(os.environ, {
         'MINIMAX_API_KEY': 'test-key-123',
@@ -287,7 +287,7 @@ class TestConfigValidation(unittest.TestCase):
     @patch.dict(os.environ, {
         'LLM_PROVIDER': 'minimax',
         'MINIMAX_API_KEY': 'test-key-123',
-        'MINIMAX_MODEL': 'MiniMax-M2.7',
+        'MINIMAX_MODEL': 'MiniMax-M3',
         'LOG_DIRECTORY': '/tmp/test-logs',
     })
     def test_config_minimax_defaults(self):
@@ -296,7 +296,7 @@ class TestConfigValidation(unittest.TestCase):
         from src.config import Config
 
         self.assertEqual(Config.MINIMAX_ENDPOINT, 'https://api.minimax.io/v1')
-        self.assertEqual(Config.MINIMAX_MODEL, 'MiniMax-M2.7')
+        self.assertEqual(Config.MINIMAX_MODEL, 'MiniMax-M3')
 
     @patch.dict(os.environ, {
         'LLM_PROVIDER': 'minimax',

--- a/03-ai-agent-for-devops/code/12/tests/test_minimax_integration.py
+++ b/03-ai-agent-for-devops/code/12/tests/test_minimax_integration.py
@@ -23,7 +23,7 @@ class TestMiniMaxIntegration(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         os.environ.setdefault('LLM_PROVIDER', 'minimax')
-        os.environ.setdefault('MINIMAX_MODEL', 'MiniMax-M2.7')
+        os.environ.setdefault('MINIMAX_MODEL', 'MiniMax-M3')
         os.environ.setdefault('LOG_DIRECTORY', '/tmp/test-logs')
         os.makedirs('/tmp/test-logs', exist_ok=True)
 

--- a/03-ai-agent-for-devops/code/13/.env.example
+++ b/03-ai-agent-for-devops/code/13/.env.example
@@ -18,7 +18,7 @@ TEMPERATURE=0.1
 # Optional: MiniMax Configuration
 # LLM_PROVIDER=minimax
 # MINIMAX_API_KEY=your_minimax_api_key_here
-# MINIMAX_MODEL=MiniMax-M2.7
+# MINIMAX_MODEL=MiniMax-M3
 
 # Optional: Log directory path
 LOG_DIRECTORY=logs

--- a/03-ai-agent-for-devops/code/13/src/config.py
+++ b/03-ai-agent-for-devops/code/13/src/config.py
@@ -26,7 +26,7 @@ class Config:
 
     # MiniMax Configuration
     MINIMAX_API_KEY = os.getenv('MINIMAX_API_KEY', '')
-    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M2.7')
+    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M3')
     MINIMAX_ENDPOINT = os.getenv('MINIMAX_ENDPOINT', 'https://api.minimax.io/v1')
     
     # Paths

--- a/03-ai-agent-for-devops/code/13/tests/test_minimax.py
+++ b/03-ai-agent-for-devops/code/13/tests/test_minimax.py
@@ -126,13 +126,13 @@ class TestMiniMaxModel(unittest.TestCase):
     })
     @patch('langchain_openai.ChatOpenAI')
     def test_minimax_default_model(self, mock_chat):
-        """Default model is MiniMax-M2.7."""
+        """Default model is MiniMax-M3."""
         _reload_all()
         from src.models.minimax import MiniMaxModel
 
         model = MiniMaxModel()
         call_kwargs = mock_chat.call_args[1]
-        self.assertEqual(call_kwargs['model'], 'MiniMax-M2.7')
+        self.assertEqual(call_kwargs['model'], 'MiniMax-M3')
 
     @patch.dict(os.environ, {
         'MINIMAX_API_KEY': 'test-key-123',
@@ -287,7 +287,7 @@ class TestConfigValidation(unittest.TestCase):
     @patch.dict(os.environ, {
         'LLM_PROVIDER': 'minimax',
         'MINIMAX_API_KEY': 'test-key-123',
-        'MINIMAX_MODEL': 'MiniMax-M2.7',
+        'MINIMAX_MODEL': 'MiniMax-M3',
         'LOG_DIRECTORY': '/tmp/test-logs',
     })
     def test_config_minimax_defaults(self):
@@ -296,7 +296,7 @@ class TestConfigValidation(unittest.TestCase):
         from src.config import Config
 
         self.assertEqual(Config.MINIMAX_ENDPOINT, 'https://api.minimax.io/v1')
-        self.assertEqual(Config.MINIMAX_MODEL, 'MiniMax-M2.7')
+        self.assertEqual(Config.MINIMAX_MODEL, 'MiniMax-M3')
 
     @patch.dict(os.environ, {
         'LLM_PROVIDER': 'minimax',

--- a/03-ai-agent-for-devops/code/13/tests/test_minimax_integration.py
+++ b/03-ai-agent-for-devops/code/13/tests/test_minimax_integration.py
@@ -23,7 +23,7 @@ class TestMiniMaxIntegration(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         os.environ.setdefault('LLM_PROVIDER', 'minimax')
-        os.environ.setdefault('MINIMAX_MODEL', 'MiniMax-M2.7')
+        os.environ.setdefault('MINIMAX_MODEL', 'MiniMax-M3')
         os.environ.setdefault('LOG_DIRECTORY', '/tmp/test-logs')
         os.makedirs('/tmp/test-logs', exist_ok=True)
 

--- a/03-ai-agent-for-devops/code/14/.env.example
+++ b/03-ai-agent-for-devops/code/14/.env.example
@@ -18,7 +18,7 @@ TEMPERATURE=0.1
 # Optional: MiniMax Configuration
 # LLM_PROVIDER=minimax
 # MINIMAX_API_KEY=your_minimax_api_key_here
-# MINIMAX_MODEL=MiniMax-M2.7
+# MINIMAX_MODEL=MiniMax-M3
 
 # Optional: Log directory path
 LOG_DIRECTORY=logs

--- a/03-ai-agent-for-devops/code/14/src/config.py
+++ b/03-ai-agent-for-devops/code/14/src/config.py
@@ -26,7 +26,7 @@ class Config:
 
     # MiniMax Configuration
     MINIMAX_API_KEY = os.getenv('MINIMAX_API_KEY', '')
-    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M2.7')
+    MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M3')
     MINIMAX_ENDPOINT = os.getenv('MINIMAX_ENDPOINT', 'https://api.minimax.io/v1')
     
     # Paths

--- a/03-ai-agent-for-devops/code/14/tests/test_minimax.py
+++ b/03-ai-agent-for-devops/code/14/tests/test_minimax.py
@@ -126,13 +126,13 @@ class TestMiniMaxModel(unittest.TestCase):
     })
     @patch('langchain_openai.ChatOpenAI')
     def test_minimax_default_model(self, mock_chat):
-        """Default model is MiniMax-M2.7."""
+        """Default model is MiniMax-M3."""
         _reload_all()
         from src.models.minimax import MiniMaxModel
 
         model = MiniMaxModel()
         call_kwargs = mock_chat.call_args[1]
-        self.assertEqual(call_kwargs['model'], 'MiniMax-M2.7')
+        self.assertEqual(call_kwargs['model'], 'MiniMax-M3')
 
     @patch.dict(os.environ, {
         'MINIMAX_API_KEY': 'test-key-123',
@@ -287,7 +287,7 @@ class TestConfigValidation(unittest.TestCase):
     @patch.dict(os.environ, {
         'LLM_PROVIDER': 'minimax',
         'MINIMAX_API_KEY': 'test-key-123',
-        'MINIMAX_MODEL': 'MiniMax-M2.7',
+        'MINIMAX_MODEL': 'MiniMax-M3',
         'LOG_DIRECTORY': '/tmp/test-logs',
     })
     def test_config_minimax_defaults(self):
@@ -296,7 +296,7 @@ class TestConfigValidation(unittest.TestCase):
         from src.config import Config
 
         self.assertEqual(Config.MINIMAX_ENDPOINT, 'https://api.minimax.io/v1')
-        self.assertEqual(Config.MINIMAX_MODEL, 'MiniMax-M2.7')
+        self.assertEqual(Config.MINIMAX_MODEL, 'MiniMax-M3')
 
     @patch.dict(os.environ, {
         'LLM_PROVIDER': 'minimax',

--- a/03-ai-agent-for-devops/code/14/tests/test_minimax_integration.py
+++ b/03-ai-agent-for-devops/code/14/tests/test_minimax_integration.py
@@ -23,7 +23,7 @@ class TestMiniMaxIntegration(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         os.environ.setdefault('LLM_PROVIDER', 'minimax')
-        os.environ.setdefault('MINIMAX_MODEL', 'MiniMax-M2.7')
+        os.environ.setdefault('MINIMAX_MODEL', 'MiniMax-M3')
         os.environ.setdefault('LOG_DIRECTORY', '/tmp/test-logs')
         os.makedirs('/tmp/test-logs', exist_ok=True)
 


### PR DESCRIPTION
## Summary

Bumps the default `MINIMAX_MODEL` in the `ai-agent-for-devops` chapter code samples from `MiniMax-M2.7` to `MiniMax-M3`, the latest MiniMax release.

Applied to chapters 10, 12, 13, 14 so the examples remain consistent:

- `src/config.py` — default value for `MINIMAX_MODEL`
- `.env.example` — commented-out example
- `tests/test_minimax.py` — default-model assertions
- `tests/test_minimax_integration.py` — `setUpClass` default
- `code/10/README.md` — provider table
- `03-ai-agent-for-devops/10-building-complex-agent-with-actions.md` — config / `.env` excerpts

## Behavior

- All existing env-var overrides still work, including `MINIMAX_MODEL=MiniMax-M2.7` and `MINIMAX_MODEL=MiniMax-M2.7-highspeed`. Only the built-in default changes.
- API endpoint (`https://api.minimax.io/v1`), temperature clamping, and provider wiring are untouched.

## Test plan

- [x] `python -m unittest tests.test_minimax` passes in `code/10`, `code/12`, `code/13`, `code/14` (21 tests each)
- [x] Integration probe reaches the MiniMax API with the new `MiniMax-M3` default (verified server-side acceptance of the model id)
- [x] Custom-model env-var passthrough (`MiniMax-M2.7`, `MiniMax-M2.7-highspeed`) still works